### PR TITLE
Match 'repo' and 'repository' key in event

### DIFF
--- a/reactor/reactor_itf.go
+++ b/reactor/reactor_itf.go
@@ -131,5 +131,9 @@ func (rd *ReactorDelivery) GetArch() string {
 
 // GetRepoName of the project's repository. If Delivery is not valid, an empty string returned.
 func (rd *ReactorDelivery) GetRepoName() string {
-	return rd.getContentString("repo")
+	repo := rd.getContentString("repo")
+	if repo == "" {
+		repo = rd.getContentString("repository")
+	}
+	return repo
 }

--- a/reactor/shell_action.go
+++ b/reactor/shell_action.go
@@ -55,6 +55,7 @@ func (shact *ShellAction) formatCommand(message *ReactorDelivery) []string {
 			"{package}", message.GetPackageName(),
 			"{arch}", message.GetArch(),
 			"{repo}", message.GetRepoName(),
+			"{repository}", message.GetRepoName(),
 		)
 		for _, p := range cmdTpl.([]string) {
 			out = append(out, fmt.Replace(p))


### PR DESCRIPTION
For some events the OBS uses 'repo' (opensuse.obs.repo.build_finished)
as key, for some 'repository' (opensuse.obs.package.build_success).
Let's make both usable for shell action.